### PR TITLE
ci: replace deprecated ::set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       id: status
       run: |
         if [ -n "$(git status --porcelain)" ]; then
-          echo "::set-output name=has_changes::1"
+          echo "has_changes=1" >> $GITHUB_OUTPUT
         fi
       shell: bash
       working-directory: Documentation/_site


### PR DESCRIPTION
The last [CI build](https://github.com/dogged/dogged/actions/runs/4303416752) on `main` has a warning that `::set-output` has been deprecated.

The functionality will stop working on 1st June 2023.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
